### PR TITLE
fix: correct SSH key file filter for pem and key files

### DIFF
--- a/app/frontend/src/components/Conn.vue
+++ b/app/frontend/src/components/Conn.vue
@@ -146,7 +146,7 @@
             </n-form-item>
             <n-form-item :label="t('conn.ssh_key_file')" path="ssh_key_file" >
               <n-flex vertical align="flex-start">
-                <n-button @click="SelectFile('ssh_key_file', '*')">.pem/.key</n-button>
+                <n-button @click="SelectFile('ssh_key_file', '*.pem;*.key')">.pem/.key</n-button>
                 <n-flex align="center" v-if="currentNode.ssh_key_file">
                   <p style="color: gray;">{{ currentNode.ssh_key_file }}</p>
                   <n-button size="tiny" @click="currentNode.ssh_key_file=''" :render-icon="renderIcon(CloseFilled)" />


### PR DESCRIPTION
- 修复 SSH 私钥文件选择器过滤规则错误的问题

- 原先使用 * 作为过滤 pattern，导致 .pem / .key 文件在原生文件对话框中的匹配行为异常

- 改为 *.pem;*.key 后，文件过滤逻辑与 Wails 约定一致，SSH 私钥文件可正常选取